### PR TITLE
Generate camera parameters from camera_info topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Project Files
 .clang_complete
+
+# Generated camera parameters
+config/generated_cam_params.yaml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ cs_add_executable(orb_slam_2_ros_node
   src/orb_slam_2_ros_node.cpp
 )
 
-cs_add_executable(utils_transform_to_tf
-  src/utils_transform_to_tf.cpp
+cs_add_executable(transform_to_tf
+  src/helpers/transform_to_tf.cpp
 )
 
 target_link_libraries(orb_slam_2_ros_node orb_slam_2_interface ${catkin_LIBRARIES})

--- a/launch/generate_cam_params.launch
+++ b/launch/generate_cam_params.launch
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- Stereo image rectification. -->
+  <node name="stereo_undistort" pkg="image_undistort" type="stereo_undistort_node">
+
+    <param name="input_camera_info_from_ros_params" value = "true"/>
+    <param name="first_camera_namespace" value="cam0"/>
+    <param name="second_camera_namespace" value="cam1"/>
+    <param name="scale" value="1.0"/>
+    <param name="process_every_nth_frame" value="1"/>
+    
+    <rosparam file="$(find orb_slam_2_ros)/config/euroc/camchain.yaml"/>
+
+    <remap from="raw/first/image" to="/cam0/image_raw"/>
+    <remap from="raw/second/image" to="/cam1/image_raw"/>
+
+  </node>
+
+  <!-- Camera parameters generation. -->
+  <node name="generate_cam_params_file" pkg="orb_slam_2_ros" type="generate_cam_params_file.py" output="screen">
+
+    <remap from="right_camera/camera_info" to="rect/second/camera_info"/>
+
+  </node>
+
+</launch>

--- a/launch/run_orb_slam_2_opencv_V1_01_easy.launch
+++ b/launch/run_orb_slam_2_opencv_V1_01_easy.launch
@@ -27,7 +27,7 @@
               world cam0_t0 100"/>
 
   <!-- Vicon ground truth. -->
-  <node name="utils_transform_to_tf" pkg="orb_slam_2_ros" type="utils_transform_to_tf" output="screen">
+  <node name="transform_to_tf" pkg="orb_slam_2_ros" type="transform_to_tf" output="screen">
     <param name="frame_id" value="world"/>
     <param name="child_frame_id" value="vicon_uav"/>
     <remap from="transform" to="/vicon/firefly_sbx/firefly_sbx"/>

--- a/launch/run_orb_slam_2_undistort_V1_01_easy.launch
+++ b/launch/run_orb_slam_2_undistort_V1_01_easy.launch
@@ -42,7 +42,7 @@
               world cam0_t0 100"/>
 
   <!-- Vicon ground truth. -->
-  <node name="utils_transform_to_tf" pkg="orb_slam_2_ros" type="utils_transform_to_tf" output="screen">
+  <node name="transform_to_tf" pkg="orb_slam_2_ros" type="transform_to_tf" output="screen">
 
     <param name="frame_id" value="world"/>
     <param name="child_frame_id" value="vicon_uav"/>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
 
   <!-- Dependencies. -->
   <depend>roscpp</depend>
+  <depend>rospy</depend>
   <depend>cmake_modules</depend>
   <depend>sensor_msgs</depend>
   <depend>glog_catkin</depend>
@@ -24,5 +25,6 @@
   <depend>pangolin_catkin</depend>
   <depend>minkindr</depend>
   <depend>minkindr_conversions</depend>
+  <depend>image_undistort</depend>
 
 </package>

--- a/src/generate_cam_params_file.py
+++ b/src/generate_cam_params_file.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+#
+#  Title:        generate_cam_params_file.py
+#  Description:  ROS module to generate camera parameters file from a camera_info (OF THE RIGHT HAND SIDE CAMERA!)
+#                topic published by a rectification node. The generated parameters 
+#                can be copied and pasted in the default yaml file read by orb_slam2. 
+#
+
+import rospy
+
+import os
+import sys
+import time
+
+from sensor_msgs.msg import CameraInfo
+
+class GenerateCamParamsFile:
+    def __init__(self):
+        rospy.loginfo(rospy.get_name() + " start")
+
+        rospy.Subscriber("right_camera/camera_info", CameraInfo,
+                         self.camera_info_callback)
+
+        rospy.spin()
+
+    def camera_info_callback(self, msg):
+
+        fx = msg.K[0]
+        fy = msg.K[4]
+        cx = msg.K[2]
+        cy = msg.K[5]
+
+        k1 = msg.D[0]
+        k2 = msg.D[1]
+        p1 = msg.D[2]
+        p2 = msg.D[3]
+
+        width = msg.width
+        height = msg.height
+
+        # msg.P[3] = -fx * baseline, ORB_SLAM_2 requires stereo baseline times fx
+        bf = -msg.P[3]
+
+        # Write params waypoints to file
+        script_path = os.path.dirname(os.path.realpath(sys.argv[0]))
+        desired_path = "%s/../config/generated_cam_params.yaml" % script_path
+        file_obj = open(desired_path, 'w')
+
+        file_obj.write("# File generated on " + time.strftime("%Y-%m-%d-%H-%M-%S") + "\n")
+        file_obj.write("#\n")
+        file_obj.write("# ----- Copy and paste the following values in the yaml file loaded by orb_slam_2_ros node. -----\n")
+        file_obj.write("#\n\n")
+        file_obj.write("# Camera Parameters. \n\n")
+
+        file_obj.write("Camera.fx: %.3f \n" % fx)
+        file_obj.write("Camera.fy: %.3f \n" % fy)
+        file_obj.write("Camera.cx: %.3f \n" % cx)
+        file_obj.write("Camera.cy: %.3f \n\n" % cy)
+
+        file_obj.write("Camera.k1: %.3f \n" % k1)
+        file_obj.write("Camera.k2: %.3f \n" % k2)
+        file_obj.write("Camera.p1: %.3f \n" % p1)
+        file_obj.write("Camera.p2: %.3f \n\n" % p2)
+
+        file_obj.write("Camera.width: %d \n" % width)
+        file_obj.write("Camera.height: %d \n\n" % height)
+
+        file_obj.write("Camera.bf: %.13f \n\n" % bf)
+
+        file_obj.close()
+
+        rospy.loginfo(rospy.get_name() + 
+            " parameters written in %s/../config/generated_cam_params.yaml" % script_path)
+        rospy.signal_shutdown("")
+
+
+if __name__ == '__main__':
+
+    rospy.init_node('generate_cam_params_file')
+
+    # Go to class functions that do all the heavy lifting. Do error checking.
+    try:
+        generate_cam_params_file = GenerateCamParamsFile()
+    except rospy.ROSInterruptException:
+        pass

--- a/src/helpers/generate_cam_params_file.py
+++ b/src/helpers/generate_cam_params_file.py
@@ -44,7 +44,7 @@ class GenerateCamParamsFile:
 
         # Write params waypoints to file
         script_path = os.path.dirname(os.path.realpath(sys.argv[0]))
-        desired_path = "%s/../config/generated_cam_params.yaml" % script_path
+        desired_path = "%s/../../config/generated_cam_params.yaml" % script_path
         file_obj = open(desired_path, 'w')
 
         file_obj.write("# File generated on " + time.strftime("%Y-%m-%d-%H-%M-%S") + "\n")
@@ -71,7 +71,7 @@ class GenerateCamParamsFile:
         file_obj.close()
 
         rospy.loginfo(rospy.get_name() + 
-            " parameters written in %s/../config/generated_cam_params.yaml" % script_path)
+            " parameters written in %s" % desired_path)
         rospy.signal_shutdown("")
 
 

--- a/src/helpers/transform_to_tf.cpp
+++ b/src/helpers/transform_to_tf.cpp
@@ -53,7 +53,7 @@ void transformCallback(const geometry_msgs::TransformStamped& msg){
 
 int main(int argc, char **argv) {
 
-  ros::init(argc, argv, "utils_transform_to_tf");
+  ros::init(argc, argv, "transform_to_tf");
   ros::NodeHandle nh;
   ros::NodeHandle nh_private("~");
   // Starting the logging


### PR DESCRIPTION
By using `roslaunch orb_slam_2_ros generate_cam_params.launch` it is possible to generate camera parameters from rectified images. These parameters are needed by the yaml file loaded by orb_slam_2_ros.

I believe this is the least invasive way to use already rectified images. In fact the catkinized version of orb_slam_2 does not need to be changed at all since the parameters are passed in the usual way. The only annoying thing is to generate cam params the first time with the above launch file and copy and paste them in the appropriate yaml file.

Helpers nodes are now placed in `src/helpers` folder.